### PR TITLE
Fix CANscope.dll's purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### CANscope
 
-CANscope is a plugin that adds NARDS and Csit to EuroScope.
+The CANscope plug-in puts the CJS (Controller's Jurisdiction Symbol) or Tracking controller's ID if you prefer just above the target, or RPS (Radar Position Symbol). Here's what it looks like:
 
 [Visit VATCAN](https://vatcan.ca)
 


### PR DESCRIPTION
The CANScope DLL does not add the CSIT and NARDS tag types, it puts the tracking controller's ID above the radar target. (Ref: http://vatcan.ca/canscope/training.html)